### PR TITLE
⚡ Bolt: Optimize matrix row conversions and loop bounds in SPN

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -29,3 +29,7 @@
 ## 2024-04-24 - [Massive memory overhead from ConvergenceHistory in IterativeSolvers.jl]
 **Learning:** In Julia's `IterativeSolvers.jl`, calling `lsmr` (or similar solvers) with `log=true` forces the internal allocation of a `ConvergenceHistory` object that tracks residuals up to `maxiter`. For large matrices where `maxiter` is set high (e.g., $100 \times N$), this causes a massive memory allocation on every call (e.g., ~1.3MB overhead per solve), severely degrading GC performance.
 **Action:** When using `IterativeSolvers.jl` in hot paths, set `log=false` to skip the history allocation and manually compute a residual norm (e.g., `norm(A * x - b) < tol`) after the solve if a convergence check is required.
+
+## 2026-05-29 - [Hoist Allocation of Tuples out of Hot Loops]
+**Learning:** In Julia, creating collections of row views or vectors using `[e for e in eachrow(matrix)]` allocates heavily (heap allocations of SubArrays or Vectors) and degrades performance inside hot loops. Converting the matrix to an array of lightweight stack-allocated Tuples (`[(mat[i,1], mat[i,2]) for i in ...]`) reduces GC pressure drastically.
+**Action:** When repeatedly passing matrix data to inner processing functions in a hot loop, hoist the invariant conversion of matrix rows to tuple arrays outside the loop, rather than allocating views or vectors repeatedly.

--- a/src/DataTransformation.jl
+++ b/src/DataTransformation.jl
@@ -114,13 +114,15 @@ function _generate_rate_variations_impl(base_variation, p_net::AbstractMatrix{In
     end
 
     vlist_as_vecs = [v for v in eachrow(base_variation["arr_vlist"]::AbstractMatrix{Int})]
+    edges_mat = base_variation["arr_edge"]::AbstractMatrix{Int}
+    edges_as_tups = [(edges_mat[i, 1], edges_mat[i, 2]) for i in 1:size(edges_mat, 1)]
 
     rate_variations = Vector{Dict{String, Any}}()
     for _ in 1:num_variations
         new_rates = rand(1:10, num_trans)
         s_probs, m_dens, avg_marks, success = generate_stochastic_net_task_with_rates(
             vlist_as_vecs,
-            [e for e in eachrow(base_variation["arr_edge"]::AbstractMatrix{Int})],
+            edges_as_tups,
             base_variation["arr_tranidx"]::Vector{Int},
             new_rates,
         )
@@ -202,7 +204,7 @@ end
 function _generate_lambda_variations_impl(petri_dict, petri_net::AbstractMatrix{Int32}, vlist::AbstractMatrix{Int}, edge_list::AbstractMatrix{Int}, tranidx::Vector{Int}, num_lambda_variations)
     num_transitions = (size(petri_net, 2) - 1) ÷ 2
     vlist_as_vecs = [v for v in eachrow(vlist)]
-    edge_as_vecs = [e for e in eachrow(edge_list)]
+    edge_as_tups = [(edge_list[i, 1], edge_list[i, 2]) for i in 1:size(edge_list, 1)]
 
     lambda_variations = Vector{Dict{String, Any}}()
     for _ in 1:num_lambda_variations
@@ -210,7 +212,7 @@ function _generate_lambda_variations_impl(petri_dict, petri_net::AbstractMatrix{
         results_dict, success = get_spn_info(
             petri_net,
             vlist_as_vecs,
-            edge_as_vecs,
+            edge_as_tups,
             tranidx,
             lambda_values,
         )

--- a/src/SPN.jl
+++ b/src/SPN.jl
@@ -8,7 +8,7 @@ function _compute_state_equation_core(num_vertices, edges, arc_transitions, lamb
     V = Vector{Float64}(undef, 2 * num_edges + num_vertices)
 
     idx = 1
-    for i in 1:num_edges
+    @inbounds for i in 1:num_edges
         edge = edges[i]
         trans_idx = arc_transitions[i]
         src_idx, dest_idx = edge[1], edge[2]
@@ -25,7 +25,7 @@ function _compute_state_equation_core(num_vertices, edges, arc_transitions, lamb
         idx += 1
     end
 
-    for j in 1:num_vertices
+    @inbounds for j in 1:num_vertices
         I[idx] = num_vertices + 1
         J[idx] = j
         V[idx] = 1.0


### PR DESCRIPTION
⚡ Bolt: Optimize matrix row conversions and loop bounds in SPN

💡 What:
- Converted `eachrow` array allocations to stack-allocated tuple arrays for edges in `DataTransformation.jl`.
- Hoisted edge array allocations out of the rate variation generation hot loop.
- Added `@inbounds` to the tight iteration loops in `_compute_state_equation_core` inside `SPN.jl`.

🎯 Why:
- Using `[e for e in eachrow(matrix)]` dynamically allocates an array of `SubArray`s on the heap. Doing this repeatedly inside the variation generation hot loop was causing thousands of unnecessary memory allocations and heavy GC pressure. By hoisting the conversion out of the loop and using lightweight stack-allocated Tuples, we drastically cut down heap allocations. Bounds checking inside tight sparse array construction loops in `_compute_state_equation_core` was also adding overhead.

📊 Impact:
- Reduces memory allocations for variation processing and makes edge handling more cache-friendly and type-stable.

🔬 Measurement:
- Verified via `Profile` and `@btime` from `BenchmarkTools` that heap allocations dropped significantly, running the test suite confirms it preserves identical behavior.

---
*PR created automatically by Jules for task [6054809912773149900](https://jules.google.com/task/6054809912773149900) started by @CombatOrpheus*